### PR TITLE
Tiny screen sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,7 +52,7 @@ header h1 {
 
 #message-row {
     /* Keeps height consistent through button hide/show */
-    height: 2.5rem;
+    height: 1.5rem;
 }
 
 #message-row button {

--- a/style.css
+++ b/style.css
@@ -35,6 +35,8 @@ body {
     justify-content: space-around;
     align-items: center;
     gap: 0.5rem;
+
+    overflow: hidden;
 }
 
 .hidden {
@@ -112,4 +114,12 @@ header h1 {
 
 footer a {
     color: var(--text-color);
+}
+
+/* Adjustments for tiny viewports */
+
+@media (max-width: 180px) {
+    header h1 {
+        font-size: 14vw;
+    }
 }

--- a/style.css
+++ b/style.css
@@ -118,6 +118,16 @@ footer a {
 
 /* Adjustments for tiny viewports */
 
+@media (max-height: 240px) {
+    header h1, footer {
+        display: none;
+    }
+
+    #board {
+        --grid-height: min(calc(95vh - 2.5rem), 85vw);
+    }
+}
+
 @media (max-width: 180px) {
     header h1 {
         font-size: 14vw;

--- a/style.css
+++ b/style.css
@@ -74,7 +74,7 @@ header h1 {
 /* Board */
 
 #board {
-    --grid-height: calc(95vmin - 9rem);
+    --grid-height: min(calc(95vh - 9rem), 85vw);
     --grid-line-breadth: clamp(2px, 1vmin, 12px);
     --cell-height: calc((var(--grid-height) * 0.33) - (var(--grid-line-breadth) * 2));
 


### PR DESCRIPTION
Grow board and shrink title h1 to available width on narrow screens.
Hide non-essential text elements on extra-short screens.