### PR TITLE
Hover revisions

### DIFF
--- a/TicTacToe.js
+++ b/TicTacToe.js
@@ -421,10 +421,16 @@ const DisplayController = (function() {
     };
 
     _refreshBoard = function() {
+        boardNode.classList.remove("x-turn");
+        boardNode.classList.remove("o-turn");
         if (TicTacToe.winner()) {
             boardNode.classList.add("win-state");
         } else {
             boardNode.classList.remove("win-state");
+            let mark = TicTacToe.currentPlayer().mark;
+            if (mark) {
+                boardNode.classList.add(`${mark.toLowerCase()}-turn`);
+            }
         }
 
         for (cellNode of cellNodes) {

--- a/style.css
+++ b/style.css
@@ -112,7 +112,7 @@ header h1 {
 }
 
 #board .cell.marked {
-    cursor: not-allowed;
+    cursor: default;
 }
 
 #board.win-state .cell.empty {

--- a/style.css
+++ b/style.css
@@ -4,6 +4,7 @@
     --grid-color: #787674;
     --text-highlight-color: #302800;
     --back-highlight-color: #fff088;
+    --text-pending-color: #24262840;
 
     --default-font: "Comic Sans", comic-sans, cursive;
 
@@ -17,6 +18,7 @@
         --grid-color: #9a9896;
         --text-highlight-color: #fffacc;
         --back-highlight-color: #484000;
+        --text-pending-color: #dadcde40;
     }
 }
 
@@ -108,7 +110,16 @@ header h1 {
 }
 
 #board .cell.empty {
+    color: var(--text-pending-color);
     cursor: pointer;
+}
+
+#board.x-turn .cell.empty:hover::after {
+    content: "X";
+}
+
+#board.o-turn .cell.empty:hover::after {
+    content: "O";
 }
 
 #board .cell.marked {

--- a/style.css
+++ b/style.css
@@ -79,6 +79,12 @@ header h1 {
     margin-left: 0.5rem;
 }
 
+#message-row button:hover {
+    color: var(--text-highlight-color);
+    border-color: var(--text-highlight-color);
+    background-color: var(--back-highlight-color);
+}
+
 /* Board */
 
 #board {


### PR DESCRIPTION
This update makes the following hover-related UX improvements:
* When an empty cell is hovered, it now shows the current player's mark at reduced visibility, helping the player picture their next move.
* Marked cells no longer show the not-allowed symbol, as this was interfering with the reset button's pointer.
* When the reset button is hovered, it now lights up with the page's highlight colors.